### PR TITLE
Images Render

### DIFF
--- a/NeuroMorph_Toolkit/Generate_3D_image_stacks.ijm
+++ b/NeuroMorph_Toolkit/Generate_3D_image_stacks.ijm
@@ -16,9 +16,9 @@
 
 originalStack= getTitle();
 mainFolder = getDirectory("Choose a directory to save the folders of separated images");
-XYFolder = mainFolder + "XY_Zstack_Images" + File.separator;
-XZFolder = mainFolder + "XZ_Ystack_Images" + File.separator;
-ZYFolder = mainFolder + "ZY_Xstack_Images" + File.separator;
+ZFolder = mainFolder + "Z_Stack" + File.separator;
+YFolder = mainFolder + "Y_Stack" + File.separator;
+XFolder = mainFolder + "X_Stack" + File.separator;
 
 getVoxelSize(xSize, ySize, zSize, unit);
 
@@ -27,38 +27,44 @@ Dialog.addMessage("Please check if the dimensions are correct");
 Dialog.addNumber("Voxel width", xSize);
 Dialog.addNumber("Voxel height", ySize);
 Dialog.addNumber("Voxel depth", zSize);
+Dialog.addCheckbox("Create Z stack", true);
 Dialog.show();
 xSize = Dialog.getNumber();
 ySize = Dialog.getNumber();
 zSize = Dialog.getNumber();
+createZ = Dialog.getCheckbox();
 
 run("Properties...", "channels=1 frames=1 unit=nm pixel_width="+xSize+" pixel_height="+ySize+" voxel_depth="+zSize+"");
 
 
-if (File.isDirectory(XYFolder) || File.isDirectory(XZFolder) || File.isDirectory(ZYFolder)) {
-	exit("Folder of XY, XZ or ZY images already found, macro aborted.");
+if ((createZ && File.isDirectory(ZFolder)) || File.isDirectory(YFolder) || File.isDirectory(XFolder)) {
+	exit("Folder of Z, Y or X stack already found, macro aborted.");
 }
 
-File.makeDirectory(XYFolder);
-File.makeDirectory(XZFolder);
-File.makeDirectory(ZYFolder);
+if (createZ) {
+	File.makeDirectory(ZFolder);
+}
+File.makeDirectory(YFolder);
+File.makeDirectory(XFolder);
 
 
 selectWindow(originalStack);
-run("Reslice [/]...", "output="+zSize+" start=Top"); // Vue du haut (XZ);
-rename("XZ_Y_");
-run("Image Sequence... ", "format=TIFF save="+XZFolder+"XZ_Y_0000.tif");
+run("Reslice [/]...", "output="+zSize+" start=Top"); // Vue du haut (Z);
+rename("Y_");
+run("Image Sequence... ", "format=TIFF save=["+YFolder+"Y_0000.tif]");
 run("Close");
 
 selectWindow(originalStack);
-run("Reslice [/]...", "output="+zSize+" start=Left rotate"); // Vue de cote (ZY);
-rename("ZY_X_");
-run("Image Sequence... ", "format=TIFF save="+ZYFolder+"ZY_X_0000.tif");
+run("Reslice [/]...", "output="+zSize+" start=Left rotate"); // Vue de cote (X);
+rename("X_");
+run("Image Sequence... ", "format=TIFF save=["+XFolder+"X_0000.tif]");
 run("Close");
 
 selectWindow(originalStack);
-rename("XY_Z_");
-run("Image Sequence... ", "format=TIFF save="+XYFolder+"XY_Z_0000.tif");
+if (createZ) {
+	rename("Z_");
+	run("Image Sequence... ", "format=TIFF save=["+ZFolder+"Z_0000.tif]");
+}
 run("Close");
 
 

--- a/NeuroMorph_Toolkit/NeuroMorph_Image_Stack_Interactions.py
+++ b/NeuroMorph_Toolkit/NeuroMorph_Image_Stack_Interactions.py
@@ -167,7 +167,7 @@ bpy.types.Scene.imagefilepaths_z = bpy.props.CollectionProperty(type=bpy.types.P
 bpy.types.Scene.imagefilepaths_x = bpy.props.CollectionProperty(type=bpy.types.PropertyGroup)
 bpy.types.Scene.imagefilepaths_y = bpy.props.CollectionProperty(type=bpy.types.PropertyGroup)
 
-bpy.context.scene.world.light_settings.use_environment_light = True
+#bpy.context.scene.world.light_settings.use_environment_light = True
 
 # Define the panel
 class SuperimposePanel(bpy.types.Panel):

--- a/NeuroMorph_Toolkit/NeuroMorph_Image_Stack_Interactions.py
+++ b/NeuroMorph_Toolkit/NeuroMorph_Image_Stack_Interactions.py
@@ -162,6 +162,27 @@ bpy.types.Scene.render_images = bpy.props.BoolProperty \
         update=update_render_images
     )
 
+def set_default_render_properties(self, context):
+
+    im_mat_list = [item for item in bpy.data.materials if (item.name =='Mat Z' or item.name =='Mat X' or item.name =='Mat Y')]
+    if (bpy.context.scene.default_render):
+        bpy.context.scene.world.light_settings.use_environment_light = True
+        for im_mat in im_mat_list:
+            im_mat.use_shadeless = True
+    else :
+        bpy.context.scene.world.light_settings.use_environment_light = False
+        for im_mat in im_mat_list:
+            im_mat.use_shadeless = False
+
+bpy.types.Scene.default_render = bpy.props.BoolProperty \
+        (
+        name="Default Render Properties",
+        description="Set on true, it set to the scene objects and images some \
+        properties needed for rendering.",
+        default=False,
+        update=set_default_render_properties
+    )
+
 bpy.types.Scene.imagefilepaths_z = bpy.props.CollectionProperty(type=bpy.types.PropertyGroup)
 bpy.types.Scene.imagefilepaths_x = bpy.props.CollectionProperty(type=bpy.types.PropertyGroup)
 bpy.types.Scene.imagefilepaths_y = bpy.props.CollectionProperty(type=bpy.types.PropertyGroup)
@@ -208,6 +229,7 @@ class SuperimposePanel(bpy.types.Panel):
 
         row = self.layout.row()
         row.prop(context.scene , "render_images")
+        row.prop(context.scene , "default_render")
 
         self.layout.label("--Retrieve Object from Image--")
 
@@ -619,16 +641,15 @@ def create_plane(im_ob):
     #Creating it's associated texture and material
     pl_ob.data.uv_textures.new()
     cTex = bpy.data.textures.new(texture_name, type = 'IMAGE')
-    mat = bpy.data.materials.new(mat_name)
+
+    if (bpy.context.scene.default_render):
+        mat = bpy.data.materials.new(mat_name)
+
+    mat.use_shadeless = True
     mtex = mat.texture_slots.add()
     mtex.texture = cTex
     mtex.texture_coords = 'UV'
     mtex.mapping = 'FLAT' 
-    # TODO Check the parameters
-    mtex.use_map_color_diffuse = True 
-    mtex.use_map_color_emission = True 
-    mtex.emission_color_factor = 0.5
-    mtex.use_map_density = True
     pl_ob.data.materials.append(mat)
     
     

--- a/NeuroMorph_Toolkit/NeuroMorph_Image_Stack_Interactions.py
+++ b/NeuroMorph_Toolkit/NeuroMorph_Image_Stack_Interactions.py
@@ -162,31 +162,12 @@ bpy.types.Scene.render_images = bpy.props.BoolProperty \
         update=update_render_images
     )
 
-def set_default_render_properties(self, context):
-
-    im_mat_list = [item for item in bpy.data.materials if (item.name =='Mat Z' or item.name =='Mat X' or item.name =='Mat Y')]
-    if (bpy.context.scene.default_render):
-        bpy.context.scene.world.light_settings.use_environment_light = True
-        for im_mat in im_mat_list:
-            im_mat.use_shadeless = True
-    else :
-        bpy.context.scene.world.light_settings.use_environment_light = False
-        for im_mat in im_mat_list:
-            im_mat.use_shadeless = False
-
-bpy.types.Scene.default_render = bpy.props.BoolProperty \
-        (
-        name="Default Render Properties",
-        description="Set on true, it set to the scene objects and images some \
-        properties needed for rendering.",
-        default=False,
-        update=set_default_render_properties
-    )
 
 bpy.types.Scene.imagefilepaths_z = bpy.props.CollectionProperty(type=bpy.types.PropertyGroup)
 bpy.types.Scene.imagefilepaths_x = bpy.props.CollectionProperty(type=bpy.types.PropertyGroup)
 bpy.types.Scene.imagefilepaths_y = bpy.props.CollectionProperty(type=bpy.types.PropertyGroup)
 
+bpy.context.scene.world.light_settings.use_environment_light = True
 
 # Define the panel
 class SuperimposePanel(bpy.types.Panel):
@@ -229,7 +210,6 @@ class SuperimposePanel(bpy.types.Panel):
 
         row = self.layout.row()
         row.prop(context.scene , "render_images")
-        row.prop(context.scene , "default_render")
 
         self.layout.label("--Retrieve Object from Image--")
 
@@ -651,8 +631,7 @@ def create_plane(im_ob):
 
 
     mat = bpy.data.materials.new(mat_name)
-    if (bpy.context.scene.default_render):
-        mat.use_shadeless = True
+    mat.use_shadeless = True
 
     mtex = mat.texture_slots.add()
     mtex.texture = cTex
@@ -1263,7 +1242,7 @@ class RemTranspButton(bpy.types.Operator):
 def register():
     bpy.utils.register_module(__name__)
     km = bpy.context.window_manager.keyconfigs.active.keymaps['3D View']
-    kmi = km.keymap_items.new(ImageScrollOperator.bl_idname, 'Y', 'PRESS', ctrl=True)
+    kmi = km.keymap_items.new(ImageScrollOperator.bl_idname, 'Y', 'PRESS', ctrl=True)    
     
    
 

--- a/NeuroMorph_Toolkit/NeuroMorph_Image_Stack_Interactions.py
+++ b/NeuroMorph_Toolkit/NeuroMorph_Image_Stack_Interactions.py
@@ -629,6 +629,11 @@ def create_plane(im_ob):
     bpy.ops.mesh.primitive_plane_add(location=pl_location, rotation=pl_rotation)
     pl_ob = bpy.context.active_object
     bpy.context.scene.objects.active = im_ob
+    isImageVisible = im_ob.hide
+    if (isImageVisible):
+        #If the image is not displayed, the parent_set function fail
+        im_ob.hide = False
+    #pl_ob.parent = im_ob
     bpy.ops.object.parent_set(keep_transform=True, type='OBJECT')
     pl_ob.dimensions = pl_dimensions
     pl_ob.lock_location[0] = True # x
@@ -637,19 +642,22 @@ def create_plane(im_ob):
     pl_ob.name = pl_name
     pl_ob.hide = True
     pl_ob.select = False
+    if (isImageVisible):
+        im_ob.hide = True
 
     #Creating it's associated texture and material
     pl_ob.data.uv_textures.new()
     cTex = bpy.data.textures.new(texture_name, type = 'IMAGE')
 
-    if (bpy.context.scene.default_render):
-        mat = bpy.data.materials.new(mat_name)
 
-    mat.use_shadeless = True
+    mat = bpy.data.materials.new(mat_name)
+    if (bpy.context.scene.default_render):
+        mat.use_shadeless = True
+
     mtex = mat.texture_slots.add()
     mtex.texture = cTex
     mtex.texture_coords = 'UV'
-    mtex.mapping = 'FLAT' 
+    mtex.mapping = 'FLAT'
     pl_ob.data.materials.append(mat)
     
     

--- a/NeuroMorph_Toolkit/NeuroMorph_Image_Stack_Interactions.py
+++ b/NeuroMorph_Toolkit/NeuroMorph_Image_Stack_Interactions.py
@@ -492,10 +492,6 @@ def DisplayImageFunction(orientation):
     for object_name in candidate_list:
        bpy.data.objects[object_name].select = True
        delete_plane(bpy.data.objects[object_name])
-#       childs = bpy.data.objects[object_name].children
-#       for child in childs:
-#        if ('Plane ' in child.name):
-#            child.select = True
     bpy.ops.object.delete()
 
     # collect selected verts
@@ -785,7 +781,7 @@ def getIndex(im_ob):
 
 @persistent
 def print_updated_objects(scene):
-    """Called after that the scene is updated. It look for the updated images and
+    """Called when that the scene is updated. It look for the updated images and
     load the image corresponding to it's actual location."""
     for im_ob in scene.objects:
         # Search for the updated objects
@@ -794,10 +790,36 @@ def print_updated_objects(scene):
             if (im_ob.name in ["Image Z","Image X","Image Y"]):
                 (ind, N, delta, orientation, image_files, locs) = getIndex(im_ob)
                 load_im(ind, image_files, im_ob, orientation)
+                if (im_ob.name == "Image Z"): 
+                    im_ob.location.z = locs[ind]
+                elif (im_ob.name == "Image X"):
+                    im_ob.location.x = locs[ind]
+                elif (im_ob.name == "Image Y"):
+                    im_ob.location.y = locs[ind]
 
 
 #The handler that call the function after each time the scene is updated.
 bpy.app.handlers.scene_update_post.append(print_updated_objects)
+
+@persistent
+def set_image_for_frame(scene):
+    """Do the same thing as print_updated_objects, when rendering plane is
+checked. Set also the texture of the planes.
+    """
+    if(bpy.context.scene.render_images):
+        for im_ob in scene.objects:
+            if (im_ob.name in ["Image Z","Image X","Image Y"]):
+                (ind, N, delta, orientation, image_files, locs) = getIndex(im_ob)
+                load_im(ind, image_files, im_ob, orientation)
+                if (im_ob.name == "Image Z"): 
+                    im_ob.location.z = locs[ind]
+                elif (im_ob.name == "Image X"):
+                    im_ob.location.x = locs[ind]
+                elif (im_ob.name == "Image Y"):
+                    im_ob.location.y = locs[ind]
+                set_texture(im_ob)
+                
+bpy.app.handlers.frame_change_post.append(set_image_for_frame)
 
 def set_texture(im_ob):
     for child in im_ob.children:
@@ -810,16 +832,6 @@ def set_texture(im_ob):
         elif child.name == 'Plane Y':
             child.data.uv_textures[0].data[0].image = im_ob.data
             child.data.materials['Mat Y'].texture_slots['Text Y'].texture.image = im_ob.data
-
-@persistent
-def set_images_texture(scene):
-    if(bpy.context.scene.render_images):
-        for im_ob in scene.objects:
-            if (im_ob.name in ["Image Z","Image X","Image Y"]):
-                set_texture(im_ob)
-
-#The handler that call the function before each rendering frame.
-bpy.app.handlers.render_pre.append(set_images_texture)
 
 class PointOperator(bpy.types.Operator):
     """Display grid on selected image for object point selection"""

--- a/NeuroMorph_Toolkit/NeuroMorph_Image_Stack_Interactions.py
+++ b/NeuroMorph_Toolkit/NeuroMorph_Image_Stack_Interactions.py
@@ -36,152 +36,14 @@ import sys
 import re
 from os import listdir
 
-# Define properties
-bpy.types.Scene.x_side = bpy.props.FloatProperty \
-      (
-        name = "x",
-        description = "x-dimension of image stack (microns)",
-        default = 1
-      )
-bpy.types.Scene.y_side = bpy.props.FloatProperty \
-      (
-        name = "y",
-        description = "y-dimension of image stack (microns)",
-        default = 1
-      )
-bpy.types.Scene.z_side = bpy.props.FloatProperty \
-      (
-        name = "z",
-        description = "z-dimension of image stack (microns)",
-        default = 1
-      )
-
-bpy.types.Scene.image_ext_Z = bpy.props.StringProperty \
-      (
-        name = "extZ",
-        description = "Image Extension Z",
-        default = ".tif"
-      )
-
-bpy.types.Scene.image_ext_X = bpy.props.StringProperty \
-        (
-        name = "extX",
-        description = "Image Extension X",
-        default = ".tif"
-    )
-
-bpy.types.Scene.image_ext_Y = bpy.props.StringProperty \
-        (
-        name="extY",
-        description="Image Extension Y",
-        default=".tif"
-    )
-      
-bpy.types.Scene.image_path_Z = bpy.props.StringProperty \
-      (
-        name = "Source_Z",
-        description = "Location of images in the stack Z",
-        default = "/"
-      )
-
-bpy.types.Scene.image_path_X = bpy.props.StringProperty \
-        (
-        name = "Source_X",
-        description = "Location of images in the stack X",
-        default = "/"
-    )
-
-bpy.types.Scene.image_path_Y = bpy.props.StringProperty \
-        (
-        name="Source_Y",
-        description="Location of images in the stack Y",
-        default="/"
-    )
-
-bpy.types.Scene.x_grid = bpy.props.IntProperty \
-      (
-        name = "nx",
-        description = "Number of grid points in x",
-        default = 50
-      )
-      
-bpy.types.Scene.y_grid = bpy.props.IntProperty \
-      (
-        name = "ny",
-        description = "Number of grid points in y",
-        default = 50
-      )
-
-bpy.types.Scene.z_grid = bpy.props.IntProperty \
-      (
-        name = "nz",
-        description = "Number of grid points in z",
-        default = 50
-      )
-
-bpy.types.Scene.file_min_Z = bpy.props.IntProperty \
-      (
-        name = "file_min_Z",
-        description = "min Z file number",
-        default = 0
-      )
-bpy.types.Scene.file_min_X = bpy.props.IntProperty \
-        (
-        name = "file_min_X",
-        description = "min X file number",
-        default=0
-    )
-bpy.types.Scene.file_min_Y = bpy.props.IntProperty \
-        (
-        name="file_min_Y",
-        description="min Y file number",
-        default=0
-    )
-
-bpy.types.Scene.shift_step = bpy.props.IntProperty \
-        (
-        name="Shift step",
-        description="Step size for scrolling through image stack while holding shift",
-        default=10
-    )
-
-def update_render_images(self, context):
-
-    im_ob_list = [item for item in bpy.data.objects if (item.name =='Image Z' or item.name =='Image X' or item.name =='Image Y')]
-    for im_ob in im_ob_list:
-       if(bpy.context.scene.render_images):
-            create_plane(im_ob)
-       else :
-            delete_plane(im_ob)
-
-bpy.types.Scene.render_images = bpy.props.BoolProperty \
-        (
-        name="Render Images",
-        description="Set on true, it will create planes with the images as textures.",
-        default=False,
-        update=update_render_images
-    )
-
-
-bpy.types.Scene.imagefilepaths_z = bpy.props.CollectionProperty(type=bpy.types.PropertyGroup)
-bpy.types.Scene.imagefilepaths_x = bpy.props.CollectionProperty(type=bpy.types.PropertyGroup)
-bpy.types.Scene.imagefilepaths_y = bpy.props.CollectionProperty(type=bpy.types.PropertyGroup)
-
 # Define the panel
 class SuperimposePanel(bpy.types.Panel):
     bl_label = "Image Stack Interactions"
     bl_space_type = "VIEW_3D"
     bl_region_type = "TOOLS"
 
-    
-    
- 
     def draw(self, context):
         self.layout.label("--Display Images from Stack--")
-
-        row = self.layout.row(align=True)
-        row.prop(context.scene, "image_path_Z")
-        row.operator("importfolder_z.tif", text='', icon='FILESEL')
 
         row = self.layout.row(align=True)
         row.prop(context.scene, "image_path_X")
@@ -190,6 +52,10 @@ class SuperimposePanel(bpy.types.Panel):
         row = self.layout.row(align=True)
         row.prop(context.scene, "image_path_Y")
         row.operator("importfolder_y.tif", text='', icon='FILESEL')
+
+        row = self.layout.row(align=True)
+        row.prop(context.scene, "image_path_Z")
+        row.operator("importfolder_z.tif", text='', icon='FILESEL')
 
         self.layout.label("Image Stack Dimensions (microns):")
         row = self.layout.row()
@@ -247,7 +113,7 @@ def active_node_mat(mat):
             return mat_node
         else:
             return mat
-    return None               
+    return None            
 
 class SelectStackFolderZ(bpy.types.Operator):  # adjusted
     """Select location of the Z stack images"""
@@ -572,6 +438,15 @@ def DisplayImageFunction(orientation):
     bpy.context.scene.objects.active = myob
     myob.select = True
     bpy.ops.object.mode_set(mode = 'OBJECT')
+
+def update_render_images(self, context):
+
+    im_ob_list = [item for item in bpy.data.objects if (item.name =='Image Z' or item.name =='Image X' or item.name =='Image Y')]
+    for im_ob in im_ob_list:
+       if(bpy.context.scene.render_images):
+            create_plane(im_ob)
+       else :
+            delete_plane(im_ob)   
 
 def create_plane(im_ob):
     x_max = bpy.context.scene.x_side
@@ -1141,7 +1016,7 @@ def pointInsideMesh(point,ob):
     ob.hide = this_visibility
 
     bpy.context.scene.update()
-
+    
     if count<6:
         return False
     else: 
@@ -1257,9 +1132,126 @@ def register():
     bpy.app.handlers.frame_change_post.append(set_image_for_frame)
     bpy.app.handlers.scene_update_post.append(print_updated_objects)
 
+    # Define properties
+    bpy.types.Scene.x_side = bpy.props.FloatProperty \
+          (
+            name = "x",
+            description = "x-dimension of image stack (microns)",
+            default = 1
+          )
+    bpy.types.Scene.y_side = bpy.props.FloatProperty \
+          (
+            name = "y",
+            description = "y-dimension of image stack (microns)",
+            default = 1
+          )
+    bpy.types.Scene.z_side = bpy.props.FloatProperty \
+          (
+            name = "z",
+            description = "z-dimension of image stack (microns)",
+            default = 1
+          )
 
+    bpy.types.Scene.image_ext_Z = bpy.props.StringProperty \
+          (
+            name = "extZ",
+            description = "Image Extension Z",
+            default = ".tif"
+          )
 
-   
+    bpy.types.Scene.image_ext_X = bpy.props.StringProperty \
+            (
+            name = "extX",
+            description = "Image Extension X",
+            default = ".tif"
+        )
+
+    bpy.types.Scene.image_ext_Y = bpy.props.StringProperty \
+            (
+            name="extY",
+            description="Image Extension Y",
+            default=".tif"
+        )
+
+    bpy.types.Scene.image_path_Z = bpy.props.StringProperty \
+          (
+            name = "Source_Z",
+            description = "Location of images in the stack Z",
+            default = "/"
+          )
+
+    bpy.types.Scene.image_path_X = bpy.props.StringProperty \
+            (
+            name = "Source_X",
+            description = "Location of images in the stack X",
+            default = "/"
+        )
+
+    bpy.types.Scene.image_path_Y = bpy.props.StringProperty \
+            (
+            name="Source_Y",
+            description="Location of images in the stack Y",
+            default="/"
+        )
+
+    bpy.types.Scene.x_grid = bpy.props.IntProperty \
+          (
+            name = "nx",
+            description = "Number of grid points in x",
+            default = 50
+          )
+
+    bpy.types.Scene.y_grid = bpy.props.IntProperty \
+          (
+            name = "ny",
+            description = "Number of grid points in y",
+            default = 50
+          )
+
+    bpy.types.Scene.z_grid = bpy.props.IntProperty \
+          (
+            name = "nz",
+            description = "Number of grid points in z",
+            default = 50
+          )
+
+    bpy.types.Scene.file_min_Z = bpy.props.IntProperty \
+          (
+            name = "file_min_Z",
+            description = "min Z file number",
+            default = 0
+          )
+    bpy.types.Scene.file_min_X = bpy.props.IntProperty \
+            (
+            name = "file_min_X",
+            description = "min X file number",
+            default=0
+        )
+    bpy.types.Scene.file_min_Y = bpy.props.IntProperty \
+            (
+            name="file_min_Y",
+            description="min Y file number",
+            default=0
+        )
+
+    bpy.types.Scene.shift_step = bpy.props.IntProperty \
+            (
+            name="Shift step",
+            description="Step size for scrolling through image stack while holding shift",
+            default=10
+        )
+    
+    bpy.types.Scene.render_images = bpy.props.BoolProperty \
+            (
+            name="Render Images",
+            description="Set on true, it will create planes with the images as textures.",
+            default=False,
+            update=update_render_images
+        )
+
+    bpy.types.Scene.imagefilepaths_z = bpy.props.CollectionProperty(type=bpy.types.PropertyGroup)
+    bpy.types.Scene.imagefilepaths_x = bpy.props.CollectionProperty(type=bpy.types.PropertyGroup)
+    bpy.types.Scene.imagefilepaths_y = bpy.props.CollectionProperty(type=bpy.types.PropertyGroup)
 
 def unregister():
     bpy.utils.unregister_module(__name__)
@@ -1267,6 +1259,27 @@ def unregister():
     bpy.app.handlers.scene_update_post.remove(print_updated_objects)
     bpy.app.handlers.frame_change_post.remove(set_image_for_frame)
     bpy.app.handlers.load_post.remove(setLightLoad)
+
+    del bpy.types.Scene.x_side
+    del bpy.types.Scene.y_side
+    del bpy.types.Scene.z_side
+    del bpy.types.Scene.image_ext_X
+    del bpy.types.Scene.image_ext_Y
+    del bpy.types.Scene.image_ext_Z
+    del bpy.types.Scene.image_path_X
+    del bpy.types.Scene.image_path_Y
+    del bpy.types.Scene.image_path_Z
+    del bpy.types.Scene.x_grid
+    del bpy.types.Scene.y_grid
+    del bpy.types.Scene.z_grid
+    del bpy.types.Scene.file_min_X
+    del bpy.types.Scene.file_min_Y
+    del bpy.types.Scene.file_min_Z
+    del bpy.types.Scene.shift_step
+    del bpy.types.Scene.render_images
+    del bpy.types.Scene.imagefilepaths_x
+    del bpy.types.Scene.imagefilepaths_y
+    del bpy.types.Scene.imagefilepaths_z
 
 if __name__ == "__main__":
     register()

--- a/NeuroMorph_Toolkit/NeuroMorph_Image_Stack_Interactions.py
+++ b/NeuroMorph_Toolkit/NeuroMorph_Image_Stack_Interactions.py
@@ -1008,7 +1008,7 @@ def pointInsideMesh(point,ob):
     outside = False
     count = 0
     for axis in axes:  # send out rays, if cross this object in every direction, point is inside
-        location,normal,index = ob.ray_cast(orig,orig+axis*max_dist)  # this will error if ob is in a different layer
+        result,location,normal,index = ob.ray_cast(orig,orig+axis*max_dist)  # this will error if ob is in a different layer
         if index != -1:
             count = count+1
 

--- a/NeuroMorph_Toolkit/NeuroMorph_Image_Stack_Interactions.py
+++ b/NeuroMorph_Toolkit/NeuroMorph_Image_Stack_Interactions.py
@@ -606,6 +606,9 @@ def create_plane(im_ob):
     bpy.context.scene.objects.active = im_ob
     bpy.ops.object.parent_set(keep_transform=True, type='OBJECT')
     pl_ob.dimensions = pl_dimensions
+    pl_ob.lock_location[0] = True # x
+    pl_ob.lock_location[1] = True # y
+    pl_ob.lock_location[2] = True # y
     pl_ob.name = pl_name
     pl_ob.hide = True
     pl_ob.select = False

--- a/NeuroMorph_Toolkit/NeuroMorph_Image_Stack_Interactions.py
+++ b/NeuroMorph_Toolkit/NeuroMorph_Image_Stack_Interactions.py
@@ -257,22 +257,23 @@ class SelectStackFolderZ(bpy.types.Operator):  # adjusted
     directory = bpy.props.StringProperty(subtype="FILE_PATH")
 
     def execute(self, context):
-        bpy.context.scene.image_path_Z = self.directory
+        if bpy.context.scene.image_path_Z != self.directory:
+            bpy.context.scene.image_path_Z = self.directory
 
-        # clear out images in blender memory
-        # (else display errors possible if previously loaded file of same name from different stack)
-        for f in bpy.data.images:
-            f.user_clear()
-            bpy.data.images.remove(f)
+            # clear out images in blender memory
+            # (else display errors possible if previously loaded file of same name from different stack)
+            for f in bpy.data.images:
+                f.user_clear()
+                bpy.data.images.remove(f)
 
-        # load image filenames and extract file extension
-        LoadImageFilenames('Z')
-        if len(bpy.context.scene.imagefilepaths_z) < 1:
-            self.report({'INFO'},"No image files found in selected directory")
-        else:
-            example_name = bpy.context.scene.imagefilepaths_z[0].name
-            file_ext = os.path.splitext(example_name)[1]
-            bpy.context.scene.image_ext_Z = file_ext
+            # load image filenames and extract file extension
+            LoadImageFilenames('Z')
+            if len(bpy.context.scene.imagefilepaths_z) < 1:
+                self.report({'INFO'},"No image files found in selected directory")
+            else:
+                example_name = bpy.context.scene.imagefilepaths_z[0].name
+                file_ext = os.path.splitext(example_name)[1]
+                bpy.context.scene.image_ext_Z = file_ext
         return {'FINISHED'}
 
     def invoke(self, context, event):
@@ -289,22 +290,23 @@ class SelectStackFolderX(bpy.types.Operator):  # adjusted
     directory = bpy.props.StringProperty(subtype="FILE_PATH")
 
     def execute(self, context):
-        bpy.context.scene.image_path_X = self.directory
+        if bpy.context.scene.image_path_X != self.directory:
+            bpy.context.scene.image_path_X = self.directory
 
-        # clear out images in blender memory
-        # (else display errors possible if previously loaded file of same name from different stack)
-        for f in bpy.data.images:
-            f.user_clear()
-            bpy.data.images.remove(f)
+            # clear out images in blender memory
+            # (else display errors possible if previously loaded file of same name from different stack)
+            for f in bpy.data.images:
+                f.user_clear()
+                bpy.data.images.remove(f)
 
-        # load image filenames and extract file extension
-        LoadImageFilenames('X')
-        if len(bpy.context.scene.imagefilepaths_x) < 1:
-            self.report({'INFO'}, "No image files found in selected directory")
-        else:
-            example_name = bpy.context.scene.imagefilepaths_x[0].name
-            file_ext = os.path.splitext(example_name)[1]
-            bpy.context.scene.image_ext_X = file_ext
+            # load image filenames and extract file extension
+            LoadImageFilenames('X')
+            if len(bpy.context.scene.imagefilepaths_x) < 1:
+                self.report({'INFO'}, "No image files found in selected directory")
+            else:
+                example_name = bpy.context.scene.imagefilepaths_x[0].name
+                file_ext = os.path.splitext(example_name)[1]
+                bpy.context.scene.image_ext_X = file_ext
         return {'FINISHED'}
 
     def invoke(self, context, event):
@@ -321,22 +323,23 @@ class SelectStackFolderY(bpy.types.Operator):  # adjusted
     directory = bpy.props.StringProperty(subtype="FILE_PATH")
 
     def execute(self, context):
-        bpy.context.scene.image_path_Y = self.directory
+        if bpy.context.scene.image_path_Y != self.directory:
+            bpy.context.scene.image_path_Y = self.directory
 
-        # clear out images in blender memory
-        # (else display errors possible if previously loaded file of same name from different stack)
-        for f in bpy.data.images:
-            f.user_clear()
-            bpy.data.images.remove(f)
+            # clear out images in blender memory
+            # (else display errors possible if previously loaded file of same name from different stack)
+            for f in bpy.data.images:
+                f.user_clear()
+                bpy.data.images.remove(f)
 
-        # load image filenames and extract file extension
-        LoadImageFilenames('Y')
-        if len(bpy.context.scene.imagefilepaths_y) < 1:
-            self.report({'INFO'}, "No image files found in selected directory")
-        else:
-            example_name = bpy.context.scene.imagefilepaths_y[0].name
-            file_ext = os.path.splitext(example_name)[1]
-            bpy.context.scene.image_ext_Y = file_ext
+            # load image filenames and extract file extension
+            LoadImageFilenames('Y')
+            if len(bpy.context.scene.imagefilepaths_y) < 1:
+                self.report({'INFO'}, "No image files found in selected directory")
+            else:
+                example_name = bpy.context.scene.imagefilepaths_y[0].name
+                file_ext = os.path.splitext(example_name)[1]
+                bpy.context.scene.image_ext_Y = file_ext
         return {'FINISHED'}
 
     def invoke(self, context, event):
@@ -373,9 +376,7 @@ def LoadImageFilenames(orientation) :
     sorted_filenames = sort_nicely([f for f in largest_group])
     the_filepaths = [os.path.join(path, f) for f in sorted_filenames]
 
-    # make sure imagefilepaths is empty
-    for ind in range(len(imagefilepaths)):
-        imagefilepaths.remove(ind)
+    imagefilepaths.clear()
 
     # insert into CollectionProperty
     for f in the_filepaths:
@@ -386,6 +387,12 @@ def LoadImageFilenames(orientation) :
     id_string = re.search('([0-9]+)', min_im_name)  # only searches filename, not full path
     file_min = int(id_string.group())
 
+    if(orientation == 'Z'):
+        bpy.context.scene.file_min_Z = file_min
+    elif (orientation == 'X'):
+        bpy.context.scene.file_min_X = file_min
+    elif (orientation == 'Y'):
+        bpy.context.scene.file_min_Y = file_min
 
 def sort_nicely( filenames ):
     # Sort the given list in the way that humans expect


### PR DESCRIPTION
To display the images in the render, the images need to be the textures of a plane.
Changes made : 
- Added a Checkbox to add the possibility to have the images in the render
- Checking it create the planes with the textures and materials associated
- Unchecking delete the planes & al.
- The texture is changed when the frame change, and correspond to the current image displayed.
- Bool option for setting some properties to True; Images shadeless and Env. lightning
- Bug fix. Changing the directories of the stacks is now safe.